### PR TITLE
With this you will be able to overwrite the remote prod url and remot…

### DIFF
--- a/bin/merge-kits
+++ b/bin/merge-kits
@@ -53,6 +53,15 @@ async def main_thread(args):
 		debug=args.debug,
 		howdy=args.howdy
 	)
+
+	if args.remote_prod_url:
+		model.release_yaml.remotes['prod']['url'] = args.remote_prod_url
+
+	if args.remote_prod_mirrors == "none" and model.release_yaml.remotes['prod']['mirrors']:
+		del model.release_yaml.remotes['prod']['mirrors']
+	elif args.remote_prod_mirrors:
+		model.release_yaml.remotes['prod']['mirrors'] = args.remote_prod_mirrors.split(",")
+
 	controller = MetaRepoJobController(model, write=True)
 	try:
 		success = await controller.generate()
@@ -71,7 +80,9 @@ CLI_CONFIG = {
 	"create_branches": {"action": "store_true", "default": False},
 	"release": {"positional": True},
 	"debug": {"action": "store_true", "default": False},
-	"howdy": {"action": "store_true", "default": False}
+	"howdy": {"action": "store_true", "default": False},
+	"remote_prod_url": {"type": str, "default": None},
+	"remote_prod_mirrors": {"type": str, "default": None}
 }
 
 


### PR DESCRIPTION
…e prod mirrors settings from console input

By providing **--remote_prod_url** you can overwrite the remote prod url defined in release.yml 

By providing **--remote_prod_mirrors** you can overwrite the remote prod mirrors defined in release.yaml. 
**--remote_prod_mirrors=none** will deactivate mirroring

Examples:
To change the remote prod url and to disable remote prod mirrors: 
```merge-kits next --prod --create_branches --remote_prod_url=git@repo:auto/{repo} --remote_prod_mirrors=none```

To change the remote prod url and remote prod mirrors: 
```merge-kits next --prod --create_branches --remote_prod_url=git@repo:auto/{repo} --remote_prod_mirrors=git@mirror:auto/{repo},git@mirror2:auto/{repo}```