### PR TITLE
Do not stop tree generation on a failing  autogen

### DIFF
--- a/metatools/tree.py
+++ b/metatools/tree.py
@@ -86,7 +86,7 @@ class Tree:
 		# TODO: we don't need to see this GitTreeError traceback
 		if retcode != 0:
 			self.log.error(f"Command failure from merge-kits: {cmd_str}")
-			raise GitTreeError(f"failed autogen in {self.root} -- offset {src_offset}.")
+#			raise GitTreeError(f"failed autogen in {self.root} -- offset {src_offset}.")
 		self.autogenned = src_offset
 
 	async def clean_tree(self):


### PR DESCRIPTION
Tested with own repo and falling  **sys-devel/binaryen-bin**
Search for "ERROR    Autogen failed" in 
[output-2024-10-27_13_56_11_log.txt](https://github.com/user-attachments/files/17534272/output-2024-10-27_13_56_11_log.txt)
